### PR TITLE
Tweak to the ht16k33 crate to reference it in a no_std safe way

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/gferon/adafruit-led-backpack.rs"
 
 [dependencies]
 embedded-hal = "0.2"
-ht16k33 = "0.4"
+ht16k33 = { version = "0.4", default-features = false }
 
 [dev-dependencies]
 rppal = { version = "0.11", features = ["hal"] }


### PR DESCRIPTION
Adds the `default-features = false` config to the upstream dependency so that users of this crate don't need the std lib.